### PR TITLE
Bottom pos

### DIFF
--- a/autoload/minimap.vim
+++ b/autoload/minimap.vim
@@ -289,7 +289,7 @@ for line in range(len(src.buffer)):
 
 
 minimap.buffer[:] = draw(lengths)
-vim.command("match WarningMsg /\%>0v\%<{}v\%>{}l\%<{}l./".format(WIDTH, topline/4, bottomline/4 - 1))
+vim.command("match WarningMsg /\%>0v\%<{}v\%>{}l\%<{}l./".format(WIDTH, topline/4, bottomline/4 + 1))
 
 # prevent any further modification
 #vim.command(":setlocal readonly")


### PR DESCRIPTION
Maybe you choose `bottomline/4 -1` for some specific reason.
However this leads to an E867 error when the length of the buffer is less than 4.
And `bottomline/4 + 1` just makes more sense to me. :smile: 
