### PR TITLE
fix a chicken and egg problem at loading.

### DIFF
--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -67,7 +67,7 @@ def ShowMinimap():
         # Restore the active window
         vim.current.window = src
     
-    vim.command(":MinimapUpdate")
+    vim.command(":call minimap#UpdateMinimap()")
 
 def UpdateMinimap():
 


### PR DESCRIPTION
If you want to put call minimap#ShowMinimap() in your vimrc, you can end
up with this error:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
    File
    "/usr/local/google/home/gbin/.vim/bundle/vim-minimap/autoload/minimap.py",
    line 70, in ShowMinimap
        vim.command(":MinimapUpdate")
        vim.error: Vim:E492: Not an editor command: :MinimapUpdate

It fixes it by calling directly the function and not the command.
