### PR TITLE
Fix trailing whitespace detection.

### DIFF
--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -100,7 +100,7 @@ def UpdateMinimap():
                 c.set(x, y)
     
         # pad with spaces to ensure uniform block highligthing
-        return [line.ljust(WIDTH, u'\u00A0') for line in c.rows()]
+        return [unicode(line).ljust(WIDTH, u'\u00A0') for line in c.rows()]
     
     
     if minimap:


### PR DESCRIPTION
Often people have a syntax highlighter for trailing whitespaces. This is
a hack using a unicode no-break space to avoid some spurious
highlightings.
