### PR TITLE
Fix for issue #17, cursor misbehaviour after calling MinimapToggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Usage
 
 Default mappings: `<Leader>mm` to display the minimap, `<Leader>mc` to close it.
 
+Or you can bind a key to the `:MinimapToggle` setting:
+nnoremap <F12> :MinimapToggle<CR>
+
 Settings
 --------
 

--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -78,8 +78,6 @@ def updateminimap():
     vim.command("normal! L")
     bottomline = src.cursor[0]
 
-    minimap = is_minimap_open()
-
 
     def draw(lengths, startline=0):
 
@@ -93,6 +91,7 @@ def updateminimap():
         return [unicode(line).ljust(WIDTH, u'\u00A0') for line in c.rows()]
 
 
+    minimap = is_minimap_open()
     if minimap:
 
         vim.current.window = minimap
@@ -127,7 +126,9 @@ def updateminimap():
         # restore the current selection if we were in visual mode.
         if mode in ('v', 'V', '\026'):
             vim.command("normal! gv")
+        src.cursor = cursor
 
+    if not minimap:
         src.cursor = cursor
 
 
@@ -154,7 +155,6 @@ def toggleminimap():
         closeminimap()
     else:
         showminimap()
-
 
 
 

--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -35,15 +35,8 @@ MINIMAP = "vim-minimap"
 
 
 def showminimap():
-    minimap = None
 
-    for b in vim.buffers:
-        if b.name.endswith(MINIMAP):
-            for w in vim.windows:
-                if w.buffer == b:
-                    minimap = w
-                    break
-
+    minimap = is_minimap_open()
     # If the minimap window does not yet exist, create it
     if not minimap:
         # Save the currently active window to restore it later
@@ -85,14 +78,8 @@ def updateminimap():
     vim.command("normal! L")
     bottomline = src.cursor[0]
 
-    minimap = None
+    minimap = is_minimap_open()
 
-    for b in vim.buffers:
-        if b.name.endswith(MINIMAP):
-            for w in vim.windows:
-                if w.buffer == b:
-                    minimap = w
-                    break
 
     def draw(lengths, startline=0):
 
@@ -145,13 +132,32 @@ def updateminimap():
 
 
 def closeminimap():
+    w = is_minimap_open()
+    if w:
+        src = vim.current.window
+        vim.current.window = w
+        vim.command(":quit!")
+        vim.current.window = src
+
+
+def is_minimap_open():
+    "Returns vim window buffer if True, else None"
+    # Globals: `vim`, `MINIMAP`
     for b in vim.buffers:
         if b.name.endswith(MINIMAP):
             for w in vim.windows:
                 if w.buffer == b:
-                    src = vim.current.window
-                    vim.current.window = w
-                    vim.command(":quit!")
-                    vim.current.window = src
-                    break
+                    return w
+
+def toggleminimap():
+    if is_minimap_open():
+        closeminimap()
+    else:
+        showminimap()
+
+
+
+
+
+
 

--- a/autoload/minimap.vim
+++ b/autoload/minimap.vim
@@ -22,8 +22,7 @@ function! minimap#ShowMinimap()
         let g:minimap_highlight = 'Visual'
     endif
 
-    " let python_module = fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))
-    let python_module = '~/.vim/bundle/vim-minimap/autoload/minimap.py'
+    let python_module = fnameescape(split(globpath(&runtimepath, 'autoload/minimap.py'), '\n')[0])
     exe "pyfile " . python_module
     python showminimap()
 endfunction
@@ -42,12 +41,7 @@ function! minimap#ToggleMinimap()
         let g:minimap_highlight = 'Visual'
     endif
 
-    let python_module = fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))
-    " -> string error! strings return with uneven quotes for some reason
-	" -> execfile('/Users/peitalin/.vim/bundle/vim-minimap/autoload/minimap.py
-	" -> SyntaxError: EOL while scanning string literal
-	" => Work around:
-    let python_module = '~/.vim/bundle/vim-minimap/autoload/minimap.py'
+    let python_module = fnameescape(split(globpath(&runtimepath, 'autoload/minimap.py'), '\n')[0])
     exe "pyfile " . python_module
     python toggleminimap()
 endfunction

--- a/autoload/minimap.vim
+++ b/autoload/minimap.vim
@@ -18,12 +18,13 @@
 
 function! minimap#ShowMinimap()
     " By default Highlight the current screen as a visual selection.
-    if !exists('g:minimap_highlight')
+    if !exists("g:minimap_highlight")
         let g:minimap_highlight = 'Visual'
     endif
 
-    let python_module = fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))
-    exe 'pyfile ' . python_module
+    " let python_module = fnameescape(globpath(&runtimepath, "autoload/minimap.py"))
+    let python_module = '/Users/peitalin/.vim/bundle/vim-minimap/autoload/minimap.py'
+    exe "pyfile " . python_module
     python showminimap()
 endfunction
 
@@ -33,5 +34,17 @@ endfunction
 
 function! minimap#CloseMinimap()
     python closeminimap()
+endfunction
+
+function! minimap#ToggleMinimap()
+    " By default Highlight the current screen as a visual selection.
+    if !exists("g:minimap_highlight")
+        let g:minimap_highlight = 'Visual'
+    endif
+
+    " let python_module = fnameescape(globpath(&runtimepath, "autoload/minimap.py"))
+    let python_module = '/Users/peitalin/.vim/bundle/vim-minimap/autoload/minimap.py'
+    exe "pyfile " . python_module
+    python toggleminimap()
 endfunction
 

--- a/autoload/minimap.vim
+++ b/autoload/minimap.vim
@@ -22,8 +22,8 @@ function! minimap#ShowMinimap()
         let g:minimap_highlight = 'Visual'
     endif
 
-    " let python_module = fnameescape(globpath(&runtimepath, "autoload/minimap.py"))
-    let python_module = '/Users/peitalin/.vim/bundle/vim-minimap/autoload/minimap.py'
+    " let python_module = fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))
+    let python_module = '~/.vim/bundle/vim-minimap/autoload/minimap.py'
     exe "pyfile " . python_module
     python showminimap()
 endfunction
@@ -42,8 +42,12 @@ function! minimap#ToggleMinimap()
         let g:minimap_highlight = 'Visual'
     endif
 
-    " let python_module = fnameescape(globpath(&runtimepath, "autoload/minimap.py"))
-    let python_module = '/Users/peitalin/.vim/bundle/vim-minimap/autoload/minimap.py'
+    let python_module = fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))
+    " -> string error! strings return with uneven quotes for some reason
+	" -> execfile('/Users/peitalin/.vim/bundle/vim-minimap/autoload/minimap.py
+	" -> SyntaxError: EOL while scanning string literal
+	" => Work around:
+    let python_module = '~/.vim/bundle/vim-minimap/autoload/minimap.py'
     exe "pyfile " . python_module
     python toggleminimap()
 endfunction

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -8,6 +8,7 @@ let loaded_minimap = 1
 command! Minimap call minimap#ShowMinimap()
 command! MinimapClose call minimap#CloseMinimap()
 command! MinimapUpdate call minimap#UpdateMinimap()
+command! MinimapToggle call minimap#ToggleMinimap()
 
 map <Leader>mm :Minimap<CR>
 map <Leader>mu :MinimapUpdate<CR>


### PR DESCRIPTION

Cursor should be able to move properly now (instead of only moving downwards) after closing the minimap.
I've added a MinimapToggle() function to play around with it.

Note: for some reason the call `fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))` returns a malformed string so I've hard coded the vim-minimap directory to the vundle directory for now...