### PR TITLE
fixed autocmd, added toggle, fixed map focus

### DIFF
--- a/autoload/minimap.vim
+++ b/autoload/minimap.vim
@@ -14,9 +14,7 @@
 " (C) 2014- by Séverin Lemaignan for the VIM integration, <severin@guakamole.org>
 " (C) 2014- by Adam Tauber for the Drawille part, <asciimoo@gmail.com>
 
-
-
-function! minimap#ShowMinimap()
+if has('python')
     " By default Highlight the current screen as a visual selection.
     if !exists('g:minimap_highlight')
         let g:minimap_highlight = 'Visual'
@@ -24,6 +22,9 @@ function! minimap#ShowMinimap()
 
     let python_module = fnameescape(globpath(&runtimepath, 'autoload/minimap.py'))
     exe 'pyfile ' . python_module
+end
+
+function! minimap#ShowMinimap()
     python showminimap()
 endfunction
 
@@ -33,5 +34,9 @@ endfunction
 
 function! minimap#CloseMinimap()
     python closeminimap()
+endfunction
+
+function! minimap#ToggleMinimap()
+    python toggleminimap()
 endfunction
 

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -5,6 +5,7 @@ endif
 
 let loaded_minimap = 1
 
+command! MinimapToggle call minimap#ToggleMinimap()
 command! Minimap call minimap#ShowMinimap()
 command! MinimapClose call minimap#CloseMinimap()
 command! MinimapUpdate call minimap#UpdateMinimap()


### PR DESCRIPTION
Fixed a 'bug' where you could focus on the minimap resulting in a minimap of the minimap ... it will now ignore updating the minimap window when focused.

Fixed a 'bug' where you could hide the minimap after hiding for instance the TagBar resulting in an exception because the previous window was none-existing. It will now search for the first active window to focus to.

Fixed a 'bug' where the autocmd still uses the minimap update function after hiding it - resulting in not properly working keys (navigation keys etc.) Placed all autocmd stuff in it's own group which will be cleared after hiding the window.

Added a new feature: A 'toggle' function just like TagBar, it's not configured by default but you can add this to your vimrc to quickly toggle the minimap:
```
nmap <F9> :MinimapToggle<CR>
```