### PR TITLE
Prevent minimap from looking aweful with wrap

### DIFF
--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -54,6 +54,8 @@ def showminimap():
         vim.command(":setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted")
         # make ensure our buffer is uncluttered
         vim.command(":setlocal nonumber norelativenumber nolist")
+        #make sure the buffer doesn't wrap.
+        vim.command(":setlocal nowrap")
 
         # Properly close the minimap when quitting VIM (ie, when minimap is the last remaining window
         vim.command(":autocmd! WinEnter <buffer> if winnr('$') == 1|q|endif")


### PR DESCRIPTION
With the following settings minimap looks terrible:
    
    autocmd! VimEnter,BufRead * Minimap
    set nolist wrap linebreak sidescrolloff=15
    set showbreak=....

Here's the proof :)
![screen shot 2015-02-27 at 11 02 55 pm](https://cloud.githubusercontent.com/assets/1757823/6424782/cf7d912a-bed4-11e4-8a40-9e99c28a6839.png)

Setting nowrap in the minimap buffer fixes the issue.
![screen shot 2015-02-27 at 11 05 24 pm](https://cloud.githubusercontent.com/assets/1757823/6424791/268ee4a0-bed5-11e4-8375-5ad229eec4fb.png)


