### PR TITLE
add details about how to overwrite the keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ Usage
 
 Default mappings: `<Leader>mm` to display the minimap, `<Leader>mc` to close it.
 
+To overwrite the default keybindings, using following settings in ``.vimrc'':
+
+```
+let g:minimap_show='<leader>ms'
+let g:minimap_update='<leader>mu'
+let g:minimap_close='<leader>gc'
+let g:g:minimap_toggle='<leader>gt'
+```
+
 Settings
 --------
 


### PR DESCRIPTION
Previous code doesn't allow user to change keybindings without touching the plugin file. 

Expose the keybinding settings by using global variables.