### PR TITLE
ft=vim-minimap for better support by 3rd party

### DIFF
--- a/autoload/minimap.py
+++ b/autoload/minimap.py
@@ -76,7 +76,7 @@ def showminimap():
 
         vim.command(":botright vnew %s" % MINIMAP)
         # make the new buffer 'temporary'
-        vim.command(":setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted")
+        vim.command(":setlocal buftype=nofile bufhidden=wipe noswapfile nobuflisted filetype=vim-minimap")
         # make ensure our buffer is uncluttered
         vim.command(":setlocal nonumber norelativenumber nolist nospell")
 


### PR DESCRIPTION
This problem was detected when a thirdparty plugin was using :set number
on vim-minimap's buffer. This change allows you to add vim-minimap as a
filetype to exclude from thirdparty plugins.