### PR TITLE
Remove default mappings; these should go in user's vimrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,18 @@ AUR just has [vim-minimap-git](https://aur.archlinux.org/packages/vim-minimap-gi
 Usage
 -----
 
-`:Minimap` to show the minimap, `:MinimapClose` to hide it.
+`:MinimapToggle` toggles the minimap, which should be all that you need.
+`:Minimap` to show, and `:MinimapClose` to hide it.
+`:MinimapUpdate` updates the minimap.
 
-Default mappings: `<Leader>mm` to display the minimap, `<Leader>mc` to close it.
+vim-minimap is a good little plugin so it doesn't define mappings.
+Example mappings for you to add to ``.vimrc'':
 
-To overwrite the default keybindings, using following settings in ``.vimrc'':
-
-```
-let g:minimap_show='<leader>ms'
-let g:minimap_update='<leader>mu'
-let g:minimap_close='<leader>gc'
-let g:minimap_toggle='<leader>gt'
+```vim
+map <Leader>mm :MinimapToggle<CR>
+map <Leader>ms :Minimap<CR>
+map <Leader>mu :MinimapUpdate<CR>
+map <Leader>mc :MinimapClose<CR>
 ```
 
 Settings

--- a/plugin/minimap.vim
+++ b/plugin/minimap.vim
@@ -8,21 +8,3 @@ command! MinimapToggle call minimap#ToggleMinimap()
 command! Minimap call minimap#ShowMinimap()
 command! MinimapClose call minimap#CloseMinimap()
 command! MinimapUpdate call minimap#UpdateMinimap()
-
-let g:minimap_show =
-      \ get( g:, 'minimap_show', '<leader>mm' )
-let g:minimap_update =
-      \ get( g:, 'minimap_update', '<leader>mu' )
-let g:minimap_close =
-      \ get( g:, 'minimap_close', '<leader>mc' )
-let g:minimap_toggle =
-      \ get( g:, 'minimap_toggle', '<leader>mt' )
-
-execute "nnoremap " . " <silent> " .
-      \ g:minimap_show . " :Minimap<CR>"
-execute "nnoremap " . " <silent> " .
-      \ g:minimap_update . " :MinimapUpdate<CR>"
-execute "nnoremap " . " <silent> " .
-      \ g:minimap_close . " :MinimapClose<CR>"
-execute "nnoremap " . " <silent> " .
-      \ g:minimap_toggle . " :MinimapToggle<CR>"


### PR DESCRIPTION
Moved the mappings to the readme; these mappings are really annoying because the instructions to remove them don't even work properly - you would have to add your vimrc earlier than the plugin gets loaded, which is not a given.